### PR TITLE
feat: refresh tokens before current token expires

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An Angular (currently 8+, lower versions could be supported) library for the [Op
 * Discovery Document
 * Code Flow
 * Refresh Tokens
-* Refresh Token before token expiring (in-progress)
+* Automatic Token Refresh before token expiring
 * Session Checks (in-progress)
 
 ## Motivation
@@ -44,7 +44,7 @@ import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
 
-import { AngularSimpleOidcModule } from 'angular-simple-oidc';
+import { AngularSimpleOidcModule, AutomaticRefreshModule } from 'angular-simple-oidc';
 
 @NgModule({
   imports: [
@@ -56,6 +56,9 @@ import { AngularSimpleOidcModule } from 'angular-simple-oidc';
       openIDProviderUrl: 'http://my.oidc.provider.com',
       scope: 'openid profile offline_access',
     }),
+
+    // For automatic token refresh.
+    // AutomaticRefreshModule,
 
   ],
   declarations: [

--- a/projects/angular-simple-oidc/src/lib/angular-simple-oidc.module.ts
+++ b/projects/angular-simple-oidc/src/lib/angular-simple-oidc.module.ts
@@ -12,11 +12,13 @@ import { TokenStorageService } from './token-storage.service';
 import { TokenEndpointClientService } from './token-endpoint-client.service';
 import { HttpClientModule } from '@angular/common/http';
 import { RefreshTokenClient } from './refresh-token-client.service';
+import { TokenEventsModule } from './token-events.module';
 
 @NgModule({
   imports: [
     HttpClientModule,
-    AngularSimpleOidcCoreModule
+    AngularSimpleOidcCoreModule,
+    TokenEventsModule
   ],
   providers: [
     {

--- a/projects/angular-simple-oidc/src/lib/auth.events.ts
+++ b/projects/angular-simple-oidc/src/lib/auth.events.ts
@@ -27,3 +27,21 @@ export class TokensReadyEvent extends SimpleOidcInfoEvent<TokenRequestResult> {
         );
     }
 }
+
+export class AccessTokenExpiredEvent extends SimpleOidcInfoEvent {
+    constructor(payload: { token: string, expiredAt: Date }) {
+        super(
+            `Access token has expired`,
+            payload
+        );
+    }
+}
+
+export class AccessTokenExpiringEvent extends SimpleOidcInfoEvent {
+    constructor(payload: { token: string, expiresAt: Date }) {
+        super(
+            `Access token is almost expired`,
+            payload
+        );
+    }
+}

--- a/projects/angular-simple-oidc/src/lib/auth.events.ts
+++ b/projects/angular-simple-oidc/src/lib/auth.events.ts
@@ -29,7 +29,7 @@ export class TokensReadyEvent extends SimpleOidcInfoEvent<TokenRequestResult> {
 }
 
 export class AccessTokenExpiredEvent extends SimpleOidcInfoEvent {
-    constructor(payload: { token: string, expiredAt: Date }) {
+    constructor(payload: { token: string, expiredAt: Date, now?: Date }) {
         super(
             `Access token has expired`,
             payload
@@ -38,7 +38,7 @@ export class AccessTokenExpiredEvent extends SimpleOidcInfoEvent {
 }
 
 export class AccessTokenExpiringEvent extends SimpleOidcInfoEvent {
-    constructor(payload: { token: string, expiresAt: Date }) {
+    constructor(payload: { token: string, expiresAt: Date, now?: Date }) {
         super(
             `Access token is almost expired`,
             payload

--- a/projects/angular-simple-oidc/src/lib/automatic-refresh.module.ts
+++ b/projects/angular-simple-oidc/src/lib/automatic-refresh.module.ts
@@ -1,0 +1,35 @@
+import { NgModule, OnDestroy } from '@angular/core';
+import { AuthService } from './auth.service';
+import { filter, takeUntil, switchMap } from 'rxjs/operators';
+import { AccessTokenExpiringEvent } from './auth.events';
+import { Subject } from 'rxjs';
+import { EventsService } from './events/events.service';
+
+@NgModule({
+  imports: [],
+  providers: [],
+  declarations: [],
+})
+export class AutomaticRefreshModule implements OnDestroy {
+
+  protected readonly destroyedSubject = new Subject();
+
+  constructor(
+    protected readonly auth: AuthService,
+    protected readonly events: EventsService,
+  ) {
+
+    this.auth.events$
+      .pipe(
+        filter((e): e is AccessTokenExpiringEvent => e instanceof AccessTokenExpiringEvent),
+        switchMap(() => this.auth.refreshAccessToken()),
+        takeUntil(this.destroyedSubject)
+      )
+      .subscribe();
+  }
+
+  public ngOnDestroy() {
+    this.destroyedSubject.next();
+    this.destroyedSubject.complete();
+  }
+}

--- a/projects/angular-simple-oidc/src/lib/core/angular-simple-oidc-core.module.ts
+++ b/projects/angular-simple-oidc/src/lib/core/angular-simple-oidc-core.module.ts
@@ -3,7 +3,7 @@ import { TokenCryptoService } from './token-crypto.service';
 import { TokenHelperService } from './token-helper.service';
 import { TokenValidationService } from './token-validation.service';
 import { TokenUrlService } from './token-url.service';
-import { RefreshTokenValidationService } from 'angular-simple-oidc';
+import { RefreshTokenValidationService } from './refresh-token/refresh-token-validation.service';
 
 @NgModule({
   imports: [

--- a/projects/angular-simple-oidc/src/lib/events/events.service.ts
+++ b/projects/angular-simple-oidc/src/lib/events/events.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { SimpleOidcEvent, SimpleOidcErrorEvent } from './models';
 import { ReplaySubject } from 'rxjs';
 import { SimpleOidcError } from '../core/errors';
-import { filter, map } from 'rxjs/operators';
 
 @Injectable({
     providedIn: 'root'

--- a/projects/angular-simple-oidc/src/lib/refresh-token-client.service.ts
+++ b/projects/angular-simple-oidc/src/lib/refresh-token-client.service.ts
@@ -2,16 +2,15 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { switchMap, take, map, withLatestFrom, tap } from 'rxjs/operators';
 import { AuthConfigService } from './config/auth-config.service';
-import {
-    TokenStorageService,
-    TokenUrlService, TokenHelperService,
-} from 'angular-simple-oidc';
 import { TokenEndpointClientService } from './token-endpoint-client.service';
 import { RefreshTokenValidationService } from './core/refresh-token/refresh-token-validation.service';
 import { TokenValidationService } from './core/token-validation.service';
 import { EventsService } from './events/events.service';
 import { SimpleOidcInfoEvent } from './events/models';
 import { TokensValidatedEvent, TokensReadyEvent } from './auth.events';
+import { TokenStorageService } from './token-storage.service';
+import { TokenUrlService } from './core/token-url.service';
+import { TokenHelperService } from './core/token-helper.service';
 
 @Injectable()
 export class RefreshTokenClient {

--- a/projects/angular-simple-oidc/src/lib/token-endpoint-client.service.spec.ts
+++ b/projects/angular-simple-oidc/src/lib/token-endpoint-client.service.spec.ts
@@ -16,9 +16,6 @@ function spyOnGet<T>(obj: T, property: keyof T) {
     return spyOnProperty(obj, property, 'get');
 }
 
-/**
- * Inspired on https://github.com/damienbod/angular-auth-oidc-client
- */
 describe('TokenEndpointClientService', () => {
     let tokenEndpointClientService: TokenEndpointClientService;
     let httpSpy: jasmine.SpyObj<HttpClient>;
@@ -60,7 +57,7 @@ describe('TokenEndpointClientService', () => {
     });
 
     it('should create', () => {
-        expect(TokenEndpointClientService).toBeTruthy();
+        expect(tokenEndpointClientService).toBeTruthy();
     });
 
     describe('call', () => {

--- a/projects/angular-simple-oidc/src/lib/token-events.module.spec.ts
+++ b/projects/angular-simple-oidc/src/lib/token-events.module.spec.ts
@@ -1,0 +1,172 @@
+import { fakeAsync, tick, flush } from '@angular/core/testing';
+import { TokenEventsModule } from './token-events.module';
+import { AuthService } from './auth.service';
+import { EventsService } from './events/events.service';
+import { TokenStorageService } from './token-storage.service';
+import { TokenHelperService } from './core/token-helper.service';
+import { of, Subject } from 'rxjs';
+import { LocalState, TokenRequestResult } from './core/models';
+import { TokensReadyEvent, AccessTokenExpiringEvent, AccessTokenExpiredEvent } from './auth.events';
+import { SimpleOidcInfoEvent } from './events/models';
+
+function spyOnGet<T>(obj: T, property: keyof T) {
+    Object.defineProperty(obj, property, { get: () => null });
+    return spyOnProperty(obj, property, 'get');
+}
+
+function getDatePlusSeconds(seconds: number) {
+    const now = new Date();
+    now.setSeconds(now.getSeconds() + seconds);
+    return now;
+}
+
+describe('TokenEventsModule', () => {
+    let authSpy: jasmine.SpyObj<AuthService>;
+    let eventServiceSpy: jasmine.SpyObj<EventsService>;
+    let storageSpy: jasmine.SpyObj<TokenStorageService>;
+    let helperSpy: jasmine.SpyObj<TokenHelperService>;
+    let eventsSpy: jasmine.Spy<InferableFunction>;
+    let currentStateSpy: jasmine.Spy<InferableFunction>;
+
+    function createEventsModule() {
+        return new TokenEventsModule(authSpy, eventServiceSpy, storageSpy, helperSpy);
+    }
+
+    beforeEach(() => {
+        authSpy = jasmine.createSpyObj('AuthService', ['events$']);
+        eventServiceSpy = jasmine.createSpyObj('EventsService', ['dispatch']);
+        storageSpy = jasmine.createSpyObj('TokenStorageService', ['currentState$']);
+        helperSpy = jasmine.createSpyObj('TokenHelperService', ['isTokenExpired']);
+
+        eventsSpy = spyOnGet(authSpy, 'events$');
+        currentStateSpy = spyOnGet(storageSpy, 'currentState$');
+
+    });
+
+    it('should create', () => {
+        currentStateSpy.and.returnValue(of());
+        eventsSpy.and.returnValue(of());
+
+        const mod = createEventsModule();
+
+        expect(mod).toBeTruthy();
+    });
+
+    describe('Token Initialization', () => {
+
+        it('should request tokens from the store on construction', () => {
+            currentStateSpy.and.returnValue(of());
+            eventsSpy.and.returnValue(of());
+
+            const mod = createEventsModule();
+
+            expect(mod).toBeTruthy();
+            expect(currentStateSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should dispatch TokensReady if valid tokens on construction', () => {
+            const state: Partial<LocalState> = {
+                accessToken: 'access-token',
+                accessTokenExpiration: 123
+            };
+            currentStateSpy.and.returnValue(of(state));
+            eventsSpy.and.returnValue(of());
+
+            helperSpy.isTokenExpired.and.returnValue(false);
+
+            const expected = new TokensReadyEvent({
+                accessToken: state.accessToken,
+                accessTokenExpiresAt: state.accessTokenExpiration,
+                decodedIdToken: state.decodedIdentityToken,
+                idToken: state.identityToken,
+                refreshToken: state.refreshToken,
+            });
+
+            createEventsModule();
+            expect(eventServiceSpy.dispatch).toHaveBeenCalledWith(expected);
+        });
+
+        it('should dispatch InfoEvent if token expired on construction', () => {
+            const state: Partial<LocalState> = {
+                accessToken: 'access-token',
+                accessTokenExpiration: 123
+            };
+            currentStateSpy.and.returnValue(of(state));
+            eventsSpy.and.returnValue(of());
+
+            helperSpy.isTokenExpired.and.returnValue(true);
+
+            const expected = new SimpleOidcInfoEvent('Have token in storage but is expired');
+
+            createEventsModule();
+            expect(eventServiceSpy.dispatch).toHaveBeenCalledWith(expected);
+        });
+    });
+
+    describe('Token Expiration Events', () => {
+        it('should dispatch TokenExpiring before TokenExpired', fakeAsync(() => {
+            const state: Partial<LocalState> = {};
+            currentStateSpy.and.returnValue(of(state));
+            const tokens: TokenRequestResult = {
+                accessToken: 'access-token',
+                accessTokenExpiresAt: getDatePlusSeconds(120).getTime()
+            };
+
+            eventsSpy.and.returnValue(of(
+                new TokensReadyEvent(tokens)
+            ));
+
+            createEventsModule();
+            tick(60000);
+            let expected = new AccessTokenExpiringEvent({
+                token: tokens.accessToken,
+                expiresAt: new Date(tokens.accessTokenExpiresAt),
+                now: new Date()
+            });
+            expect(eventServiceSpy.dispatch).toHaveBeenCalledWith(expected);
+
+            tick(60000);
+            expected = new AccessTokenExpiredEvent({
+                token: tokens.accessToken,
+                expiredAt: new Date(tokens.accessTokenExpiresAt),
+                now: new Date()
+            });
+            expect(eventServiceSpy.dispatch).toHaveBeenCalledWith(expected);
+        }));
+
+        it('should not configure dispatchers if no access token', fakeAsync(() => {
+            const state: Partial<LocalState> = {};
+            currentStateSpy.and.returnValue(of(state));
+            const tokens: TokenRequestResult = {};
+
+            eventsSpy.and.returnValue(of(
+                new TokensReadyEvent(tokens)
+            ));
+
+            createEventsModule();
+            flush();
+            expect(eventServiceSpy.dispatch).toHaveBeenCalledWith(
+                new SimpleOidcInfoEvent('TokenExpired event not configured due to access token or expiration empty.'));
+        }));
+
+        it('should unsubscribe when destroyed', fakeAsync(() => {
+            currentStateSpy.and.returnValue(of());
+
+            const subject = new Subject<TokensReadyEvent>();
+
+            eventsSpy.and.returnValue(subject.asObservable());
+
+            const mod = createEventsModule();
+
+            subject.next(new TokensReadyEvent({}));
+            flush();
+            expect(eventServiceSpy.dispatch).toHaveBeenCalledTimes(1);
+
+            mod.ngOnDestroy();
+
+            subject.next(new TokensReadyEvent({}));
+            flush();
+            expect(eventServiceSpy.dispatch).toHaveBeenCalledTimes(1);
+        }));
+    });
+});

--- a/projects/angular-simple-oidc/src/lib/token-events.module.ts
+++ b/projects/angular-simple-oidc/src/lib/token-events.module.ts
@@ -1,0 +1,98 @@
+import { NgModule, OnDestroy } from '@angular/core';
+import { AuthService } from './auth.service';
+import { filter, takeUntil, delay, switchMap, map, take } from 'rxjs/operators';
+import { TokensReadyEvent, AccessTokenExpiredEvent, AccessTokenExpiringEvent } from './auth.events';
+import { Subject, of, merge } from 'rxjs';
+import { EventsService } from './events/events.service';
+import { SimpleOidcInfoEvent } from './events/models';
+import { TokenStorageService } from './token-storage.service';
+import { TokenHelperService } from './core/token-helper.service';
+
+@NgModule({
+  imports: [],
+  providers: [],
+  declarations: [],
+})
+export class TokenEventsModule implements OnDestroy {
+
+  protected readonly destroyedSubject = new Subject();
+
+  constructor(
+    protected readonly auth: AuthService,
+    protected readonly events: EventsService,
+    protected readonly storage: TokenStorageService,
+    protected readonly tokenHelper: TokenHelperService,
+  ) {
+
+    // Initialize memory with persisted storage.
+    storage.currentState$
+      .pipe(take(1))
+      .subscribe(state => {
+        if (state.accessToken || state.identityToken || state.refreshToken) {
+          if (!tokenHelper.isTokenExpired(state.accessTokenExpiration)) {
+            this.events.dispatch(new TokensReadyEvent({
+              accessToken: state.accessToken,
+              accessTokenExpiresAt: state.accessTokenExpiration,
+              decodedIdToken: state.decodedIdentityToken,
+              idToken: state.identityToken,
+              refreshToken: state.refreshToken,
+            }));
+          } else {
+            this.events.dispatch(new SimpleOidcInfoEvent('Have token in storage but is expired'));
+          }
+        }
+      });
+
+    this.watchTokenExpiration();
+  }
+
+  /**
+   * Sets timeouts based on the token expiration.
+   * Dispatches AccessTokenExpiringEvent before the access token expires (grace period)
+   * Dispatches AccessTokenExpiredEvent when the access token expires.
+   */
+  public watchTokenExpiration() {
+    this.auth.events$
+      .pipe(
+        filter((e): e is TokensReadyEvent => e instanceof TokensReadyEvent),
+        switchMap(({ payload }) => {
+          if (payload.accessToken && payload.accessTokenExpiresAt) {
+
+            const expiration = new Date(payload.accessTokenExpiresAt);
+
+            // TODO: Expose as config?
+            const gracePeriod = 60;
+            const beforeExpiration = new Date(payload.accessTokenExpiresAt);
+            beforeExpiration.setSeconds(beforeExpiration.getSeconds() - gracePeriod);
+
+            const expiring$ = of(new AccessTokenExpiringEvent({
+              token: payload.accessToken,
+              expiresAt: expiration
+            })).pipe(
+              delay(beforeExpiration)
+            );
+
+            const expired$ = of(new AccessTokenExpiredEvent({
+              token: payload.accessToken,
+              expiredAt: expiration
+            })).pipe(
+              delay(expiration)
+            );
+
+            return merge(expiring$, expired$);
+          } else {
+            return of(new SimpleOidcInfoEvent('TokenExpired event not configured due to access token or expiration empty.'));
+          }
+        }),
+        takeUntil(this.destroyedSubject),
+      ).subscribe(e => {
+        e.payload.now = new Date();
+        this.events.dispatch(e);
+      });
+  }
+
+  public ngOnDestroy() {
+    this.destroyedSubject.next();
+    this.destroyedSubject.complete();
+  }
+}

--- a/projects/angular-simple-oidc/src/lib/token-events.module.ts
+++ b/projects/angular-simple-oidc/src/lib/token-events.module.ts
@@ -1,6 +1,6 @@
 import { NgModule, OnDestroy } from '@angular/core';
 import { AuthService } from './auth.service';
-import { filter, takeUntil, delay, switchMap, map, take } from 'rxjs/operators';
+import { filter, takeUntil, delay, switchMap, take } from 'rxjs/operators';
 import { TokensReadyEvent, AccessTokenExpiredEvent, AccessTokenExpiringEvent } from './auth.events';
 import { Subject, of, merge } from 'rxjs';
 import { EventsService } from './events/events.service';
@@ -86,7 +86,10 @@ export class TokenEventsModule implements OnDestroy {
         }),
         takeUntil(this.destroyedSubject),
       ).subscribe(e => {
-        e.payload.now = new Date();
+        if (e.payload) {
+          e.payload.now = new Date();
+        }
+
         this.events.dispatch(e);
       });
   }

--- a/projects/angular-simple-oidc/src/lib/token-storage.service.spec.ts
+++ b/projects/angular-simple-oidc/src/lib/token-storage.service.spec.ts
@@ -1,54 +1,20 @@
 import { TestBed, fakeAsync, flush } from '@angular/core/testing';
 import { TokenStorageService } from './token-storage.service';
 import { LOCAL_STORAGE_REF } from './constants';
-import { TokenStorageKeys, LocalState, DecodedIdentityToken, TokenRequestResult } from './core/models';
-import { EventsService } from './events/events.service';
-import { TokensReadyEvent } from './auth.events';
-
-class FakeStorage implements Storage {
-    [name: string]: any;
-    public readonly length: number;
-    private readonly map = new Map<string, string>();
-
-    public clear(): void {
-        throw new Error('Method not implemented.');
-    }
-
-    public getItem(key: string): string {
-        return this.map.get(key);
-    }
-
-    public key(index: number): string {
-        throw new Error('Method not implemented.');
-    }
-
-    public removeItem(key: string): void {
-        this.map.delete(key);
-    }
-
-    public setItem(key: string, value: string): void {
-        this.map.set(key, value);
-    }
-}
+import { TokenStorageKeys, LocalState, TokenRequestResult } from './core/models';
 
 describe('TokenStorageService', () => {
     let tokenStorage: TokenStorageService;
     let storageSpy: jasmine.SpyObj<Storage>;
-    let eventsSpy: jasmine.SpyObj<EventsService>;
 
     beforeEach(() => {
         storageSpy = jasmine.createSpyObj('Storage', ['setItem', 'getItem', 'removeItem']);
-        eventsSpy = jasmine.createSpyObj('EventsService', ['dispatch']);
 
         TestBed.configureTestingModule({
             providers: [
                 {
                     provide: LOCAL_STORAGE_REF,
                     useValue: storageSpy
-                },
-                {
-                    provide: EventsService,
-                    useValue: eventsSpy,
                 },
                 TokenStorageService
             ],
@@ -59,17 +25,6 @@ describe('TokenStorageService', () => {
 
     it('should create', () => {
         expect(tokenStorage).toBeTruthy();
-    });
-
-    it('should dispatch TokenObtainedEvents on construction', () => {
-        storageSpy.getItem.and.returnValue('{}');
-
-        const service = new TokenStorageService(storageSpy, eventsSpy);
-
-        expect(service).toBeTruthy();
-
-        expect(eventsSpy.dispatch).toHaveBeenCalled();
-
     });
 
     describe('storePreAuthorizationState', () => {
@@ -91,30 +46,6 @@ describe('TokenStorageService', () => {
             expect(storageSpy.setItem).toHaveBeenCalledWith(TokenStorageKeys.CodeVerifier, codeVerifier);
             expect(storageSpy.setItem).toHaveBeenCalledWith(TokenStorageKeys.PreRedirectUrl, preRedirectUrl);
         }));
-
-        // it('should return newly stored params', fakeAsync(() => {
-        //     const nonce = 'nonce';
-        //     const state = 'state';
-        //     const codeVerifier = 'codeVerifier';
-        //     const preRedirectUrl = 'preRedirectUri';
-
-        //     const storage = new FakeStorage();
-        //     storageSpy.setItem.and.callFake((k, v) => storage.setItem(k, v));
-        //     storageSpy.getItem.and.callFake((k) => storage.getItem(k));
-
-        //     let output: LocalState;
-        //     tokenStorage.storePreAuthorizationState({
-        //         nonce, state, codeVerifier, preRedirectUrl
-        //     }).subscribe(s => output = s);
-
-        //     flush();
-
-        //     expect(output.nonce).toBe(nonce);
-        //     expect(output.state).toBe(state);
-        //     expect(output.codeVerifier).toBe(codeVerifier);
-        //     expect(output.preRedirectUrl).toBe(preRedirectUrl);
-
-        // }));
     });
 
     describe('clearPreAuthorizationState', () => {

--- a/projects/angular-simple-oidc/src/lib/token-storage.service.ts
+++ b/projects/angular-simple-oidc/src/lib/token-storage.service.ts
@@ -5,8 +5,6 @@ import {
 } from './core/models';
 import { of, BehaviorSubject } from 'rxjs';
 import { LOCAL_STORAGE_REF } from './constants';
-import { EventsService } from './events/events.service';
-import { TokensReadyEvent } from './auth.events';
 
 // @dynamic
 @Injectable()
@@ -20,25 +18,12 @@ export class TokenStorageService {
         return this.localStorage;
     }
 
-    protected readonly localStateSubject: BehaviorSubject<LocalState>;
+    protected readonly localStateSubject = new BehaviorSubject<LocalState>(this.getCurrentLocalState());
 
     constructor(
         @Inject(LOCAL_STORAGE_REF)
         private readonly localStorage: Storage,
-        private readonly events: EventsService,
-    ) {
-        const state = this.getCurrentLocalState();
-        this.localStateSubject = new BehaviorSubject(state);
-        if (state.accessToken || state.identityToken || state.refreshToken) {
-            this.events.dispatch(new TokensReadyEvent({
-                accessToken: state.accessToken,
-                accessTokenExpiresAt: state.accessTokenExpiration,
-                decodedIdToken: state.decodedIdentityToken,
-                idToken: state.identityToken,
-                refreshToken: state.refreshToken,
-            }));
-        }
-    }
+    ) { }
 
     public storePreAuthorizationState(authState: {
         nonce: string,

--- a/projects/angular-simple-oidc/src/public-api.ts
+++ b/projects/angular-simple-oidc/src/public-api.ts
@@ -35,3 +35,5 @@ export * from './lib/auth.events';
 
 export { RefreshTokenClient } from './lib/refresh-token-client.service';
 export { RefreshTokenValidationService } from './lib/core/refresh-token/refresh-token-validation.service';
+
+export { AutomaticRefreshModule } from './lib/automatic-refresh.module';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { NgModule } from '@angular/core';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 
-import { AngularSimpleOidcModule } from 'angular-simple-oidc';
+import { AngularSimpleOidcModule, AutomaticRefreshModule } from 'angular-simple-oidc';
 import { HomeComponent } from './home/home.component';
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,8 @@ import { HomeComponent } from './home/home.component';
       scope: 'openid profile offline_access',
     }),
 
+    AutomaticRefreshModule,
+
     AppRoutingModule,
 
   ],


### PR DESCRIPTION
Introduces two new events:
AccessTokenExpiringEvent: n seconds before token expires
AccessTokenExpiredEvent: when the token has expired

When the AccessTokenExpiringEvent is fired, token endpoint
will be consumed using the refresh_token.
If the token is renewed, AccessTokenExpiredEvent will not be fired.

fixes #1 